### PR TITLE
Create and update for groups, scenes, and participants

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,14 +14,14 @@ A list of all protocol level methods and this client's support of them. Used to 
 
 - [ ] getAllParticipants
 - [ ] getActiveParticipants
-- [ ] updateParticipants
+- [x] updateParticipants
 
-- [ ] createGroups
-- [ ] updateGroups
+- [x] createGroups
+- [x] updateGroups
 
-- [ ] createScenes
+- [x] createScenes
 - [ ] deleteScene
-- [ ] updateScenes
+- [x] updateScenes
 
 - [X] createControls
 - [X] deleteControls

--- a/examples/groups.ts
+++ b/examples/groups.ts
@@ -1,0 +1,207 @@
+/* tslint:disable:no-console */
+import * as WebSocket from 'ws';
+
+import {
+    GameClient,
+    IButtonData,
+    IControlData,
+    ISceneDataArray,
+    IParticipant,
+    setWebSocket,
+    Group
+} from '../lib';
+
+if (process.argv.length < 4) {
+    console.log('Usage gameClient.exe <token> <versionId>');
+    console.log(process.argv);
+    process.exit();
+}
+
+// We need to tell the interactive client what type of websocket we are using.
+setWebSocket(WebSocket);
+
+// As we're on the Streamer's side we need a "GameClient" instance
+const client = new GameClient();
+
+// Log when we're connected to interactive
+client.on('open', () => console.log('Connected to interactive'));
+
+// A collection of interval timers, one for each participant
+const participantTimers: Map<string, number> = new Map<string, number>();
+
+// The time between when we switch groups for each participant
+const delayTime = 2000;
+
+// These can be un-commented to see the raw JSON messages under the hood
+// client.on('message', (err: any) => console.log('<<<', err));
+// client.on('send', (err: any) => console.log('>>>', err));
+// client.on('error', (err: any) => console.log(err));
+
+/**
+ * This makes button objects with the text set to the name of the scene.
+ */
+function makeControls(scene: string): IControlData[] {
+    const controls: IButtonData[] = [];
+    const size = 30;
+    controls.push({
+        controlID: 'control0',
+        kind: 'button',
+        text: `Scene: ${scene}`,
+        cost: 1,
+        position: [
+                {
+                    size: 'large',
+                    width: size,
+                    height: size / 2,
+                    x: 1,
+                    y: 1,
+                },
+                {
+                    size: 'small',
+                    width: size,
+                    height: size / 2,
+                    x: 1,
+                    y: 1,
+                },
+                {
+                    size: 'medium',
+                    width: size,
+                    height: size,
+                    x: 1,
+                    y: 1,
+                },
+            ],
+        },
+    );
+    return controls;
+}
+
+/**
+ * Swaps the group the current participant is in between secondGroup and default.
+ */
+function swapParticipantGroup(participant: IParticipant): Promise<void> {
+    if (participant.groupID === 'default') {
+        participant.groupID = 'secondGroup';
+    } else {
+        participant.groupID = 'default';
+    }
+
+    return client.updateParticipants({
+        participants: [participant]
+    })
+}
+
+/**
+ * Removes the participant info from the participantTimers map and stops their timer.
+ */
+function removeParticipant(participantSessionId: string): void {
+    if (participantTimers.has(participantSessionId)) {
+        clearInterval(participantTimers[participantSessionId]);
+        delete participantTimers[participantSessionId];
+    }
+}
+
+/**
+ * Create the scenes used by the application.
+ */
+function createScenes(): Promise<ISceneDataArray> {
+    const defaultScene = client.state.getScene('default');
+    defaultScene.createControls(makeControls('default'));
+
+    const secondScene = {
+        sceneID: 'secondScene',
+        controls: makeControls('second')
+    };
+    
+    return client.createScenes({
+        scenes: [secondScene]
+    });
+}
+
+/**
+ * Create and setup the groups used by the application.
+ */
+function createGroups(): Promise<void> {
+    const defaultGroup = client.state.getGroup('default');
+    defaultGroup.sceneID = 'default';
+
+    const secondGroup = new Group(
+        {
+            groupID: 'secondGroup',
+            sceneID: 'secondScene'
+        }
+    );
+
+    const thirdGroup = new Group(
+        {
+            groupID: 'thirdGroup',
+            sceneID: 'default'
+        }
+    );
+    
+    return client
+        // First update the default group
+        .updateGroups({
+            groups: [defaultGroup]
+        })
+
+        // Then create the new groups
+        .then(() => client.createGroups({
+                groups: [secondGroup, thirdGroup]
+            })
+        )
+
+        // Then delete the third group
+        .then(() => client.deleteGroup({
+            groupID: thirdGroup.groupID,
+            reassignGroupID: defaultGroup.groupID
+        }));
+}
+
+// Now we open the connection passing in our authentication details and an experienceId.
+client
+    // Open the Beam client with command line args
+    .open({
+        authToken: process.argv[2],
+        versionId: parseInt(process.argv[3], 10),
+    })
+    
+    // Pull the scenes from the interactive server
+    .then(() => client.synchronizeScenes())
+
+    // Pull the groups from the interactive server
+    .then(() => client.synchronizeGroups())
+
+    // Set the client as ready so that interactive controls show up
+    .then(() => client.ready(true))
+
+    // Create the scenes for our application
+    .then(createScenes)
+
+    // Create the groups for our application
+    .then(createGroups)
+
+    // Catch any errors
+    .catch((reason) => console.error("Promise rejected", reason));
+
+client.state.on('participantJoin', (participant: IParticipant ) => {
+    console.log(`${participant.username}(${participant.sessionID}) Joined`);
+
+    if (!participantTimers.has(participant.sessionID)) {
+        participantTimers[participant.sessionID] = setInterval(() => {
+            const p = client.state.getParticipantBySessionID(participant.sessionID);
+
+            if (p) {
+                swapParticipantGroup(p);
+            } else {
+                removeParticipant(participant.sessionID);
+            }
+        }, delayTime);
+    }
+});
+
+client.state.on('participantLeave', (participant: string ) => {
+    console.log(`${participant} Left`);
+    removeParticipant(participant)
+});
+/* tslint:enable:no-console */

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -10,11 +10,11 @@ import {
     IGroupDataArray,
     IGroupDeletionParams,
     IInput,
+    IParticipantArray,
     IScene,
     ISceneControlDeletion,
     ISceneData,
     ISceneDataArray,
-    IParticipantArray,
     ITransactionCapture,
 } from './state/interfaces';
 import { IState } from './state/IState';
@@ -279,7 +279,7 @@ export class Client extends EventEmitter implements IClient {
     }
 
     public updateParticipants(_: IParticipantArray): Promise<void> {
-        throw new PermissionDeniedError('updateParticipants', 'Participant')
+        throw new PermissionDeniedError('updateParticipants', 'Participant');
     }
 
     public giveInput<T extends IInput>(_: T): Promise<void> {
@@ -289,7 +289,7 @@ export class Client extends EventEmitter implements IClient {
     public deleteControls(_: ISceneControlDeletion): Promise<void> {
         throw new PermissionDeniedError('deleteControls', 'Participant');
     }
-    
+
     public deleteGroup(_: IGroupDeletionParams): Promise<void> {
         throw new PermissionDeniedError('deleteGroup', 'Participant');
     }

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -6,11 +6,15 @@ import { MethodHandlerManager } from './methods/MethodHandlerManager';
 import { onReadyParams } from './methods/methodTypes';
 import {
     IControl,
+    IGroup,
+    IGroupDataArray,
+    IGroupDeletionParams,
     IInput,
     IScene,
     ISceneControlDeletion,
     ISceneData,
     ISceneDataArray,
+    IParticipantArray,
     ITransactionCapture,
 } from './state/interfaces';
 import { IState } from './state/IState';
@@ -178,6 +182,21 @@ export class Client extends EventEmitter implements IClient {
     }
 
     /**
+     * Retrieves the groups stored on the interactive server.
+     */
+    public getGroups(): Promise<IGroupDataArray> {
+        return this.execute('getGroups', null, false);
+    }
+
+    /**
+     * Retrieves the groups on the server and hydrates the state store with them.
+     */
+    public synchronizeGroups(): Promise<IGroup[]> {
+        return this.getGroups()
+            .then(res => this.state.synchronizeGroups(res));
+    }
+
+    /**
      * Gets the time from the server as a unix timestamp in UTC.
      */
     public getTime(): Promise<number> {
@@ -239,12 +258,28 @@ export class Client extends EventEmitter implements IClient {
         throw new PermissionDeniedError('createControls', 'Participant');
     }
 
+    public createGroups(_: IGroupDataArray): Promise<void> {
+        throw new PermissionDeniedError('createGroups', 'Participant');
+    }
+
+    public createScenes(_: ISceneDataArray): Promise<ISceneDataArray> {
+        throw new PermissionDeniedError('createScenes', 'Participant');
+    }
+
     public updateControls(_: ISceneData): Promise<void> {
         throw new PermissionDeniedError('updateControls', 'Participant');
     }
 
+    public updateGroups(_: IGroupDataArray): Promise<IGroupDataArray> {
+        throw new PermissionDeniedError('updateGroups', 'Participant');
+    }
+
     public updateScenes(_: ISceneDataArray): Promise<void> {
         throw new PermissionDeniedError('updateScenes', 'Participant');
+    }
+
+    public updateParticipants(_: IParticipantArray): Promise<void> {
+        throw new PermissionDeniedError('updateParticipants', 'Participant')
     }
 
     public giveInput<T extends IInput>(_: T): Promise<void> {
@@ -253,6 +288,10 @@ export class Client extends EventEmitter implements IClient {
 
     public deleteControls(_: ISceneControlDeletion): Promise<void> {
         throw new PermissionDeniedError('deleteControls', 'Participant');
+    }
+    
+    public deleteGroup(_: IGroupDeletionParams): Promise<void> {
+        throw new PermissionDeniedError('deleteGroup', 'Participant');
     }
 
     public ready(_: boolean): Promise<void> {

--- a/src/GameClient.ts
+++ b/src/GameClient.ts
@@ -1,7 +1,14 @@
 import { Client, ClientType } from './Client';
 import { EndpointDiscovery } from './EndpointDiscovery';
 import { Requester } from './Requester';
-import { ISceneControlDeletion, ISceneData, ISceneDataArray } from './state/interfaces';
+import {
+    ISceneControlDeletion,
+    ISceneData,
+    ISceneDataArray,
+    IParticipantArray,
+    IGroupDataArray,
+    IGroupDeletionParams
+} from './state/interfaces';
 import { IControl } from './state/interfaces/controls/IControl';
 
 export interface IGameClientOptions {
@@ -59,6 +66,20 @@ export class GameClient extends Client {
     }
 
     /**
+     * Instructs the server to create new groups with the specified parameters.
+     */
+    public createGroups(groups: IGroupDataArray): Promise<void> {
+        return this.execute('createGroups', groups, false);
+    }
+
+    /**
+     * Instructs the server to create new scenes with the specified parameters.
+     */
+    public createScenes(scenes: ISceneDataArray): Promise<ISceneDataArray> {
+        return this.execute('createScenes', scenes, false);
+    }
+
+    /**
      * Updates a sessions' ready state, when a client is not ready participants cannot
      * interact with the controls.
      */
@@ -74,11 +95,26 @@ export class GameClient extends Client {
         return this.execute('updateControls', params, false);
     }
 
+    /** 
+     * Instructs the server to update the participant within the session with your specified parameters.
+     * Participants within the group will see applicable scene changes automatically.
+     */
+    public updateGroups(groups: IGroupDataArray): Promise<IGroupDataArray> {
+        return this.execute('updateGroups', groups, false);
+    }
+
     /**
      * Instructs the server to update a scene within the session with your specified parameters.
      */
     public updateScenes(scenes: ISceneDataArray): Promise<void> {
         return this.execute('updateScenes', scenes, false);
+    }
+
+    /** 
+     * Instructs the server to update the participant within the session with your specified parameters.
+     */
+    public updateParticipants(participants: IParticipantArray): Promise<void> {
+        return this.execute('updateParticipants', participants, false)
     }
 
     /**
@@ -98,5 +134,12 @@ export class GameClient extends Client {
      */
     public deleteControls(data: ISceneControlDeletion): Promise<void> {
         return this.execute('deleteControls', data, false);
+    }
+
+    /**
+     * Instructs the server to delete the provided group.
+     */
+    public deleteGroup(data: IGroupDeletionParams): Promise<void> {
+        return this.execute('deleteGroup', data, false);
     }
 }

--- a/src/GameClient.ts
+++ b/src/GameClient.ts
@@ -2,12 +2,12 @@ import { Client, ClientType } from './Client';
 import { EndpointDiscovery } from './EndpointDiscovery';
 import { Requester } from './Requester';
 import {
+    IGroupDataArray,
+    IGroupDeletionParams,
+    IParticipantArray,
     ISceneControlDeletion,
     ISceneData,
     ISceneDataArray,
-    IParticipantArray,
-    IGroupDataArray,
-    IGroupDeletionParams
 } from './state/interfaces';
 import { IControl } from './state/interfaces/controls/IControl';
 
@@ -95,7 +95,7 @@ export class GameClient extends Client {
         return this.execute('updateControls', params, false);
     }
 
-    /** 
+    /**
      * Instructs the server to update the participant within the session with your specified parameters.
      * Participants within the group will see applicable scene changes automatically.
      */
@@ -110,11 +110,11 @@ export class GameClient extends Client {
         return this.execute('updateScenes', scenes, false);
     }
 
-    /** 
+    /**
      * Instructs the server to update the participant within the session with your specified parameters.
      */
     public updateParticipants(participants: IParticipantArray): Promise<void> {
-        return this.execute('updateParticipants', participants, false)
+        return this.execute('updateParticipants', participants, false);
     }
 
     /**

--- a/src/IClient.ts
+++ b/src/IClient.ts
@@ -4,10 +4,13 @@ import { ClientType } from './Client';
 import { InteractiveError } from './errors';
 import {
     IControl,
+    IGroupDeletionParams,
+    IGroupDataArray,
     IInput,
     ISceneControlDeletion,
     ISceneData,
     ISceneDataArray,
+    IParticipantArray
 } from './state/interfaces';
 import { IState } from './state/IState';
 
@@ -18,9 +21,14 @@ export interface IClient extends EventEmitter {
     ready(isReady: boolean): Promise<void>;
 
     createControls(controls: ISceneData): Promise<IControl[]>;
+    createGroups(groups: IGroupDataArray): Promise<void>;
+    createScenes(scenes: ISceneDataArray): Promise<ISceneDataArray>;
     updateControls(controls: ISceneData): Promise<void>;
+    updateGroups(groups: IGroupDataArray): Promise<IGroupDataArray>;
     deleteControls(controls: ISceneControlDeletion): Promise<void>;
+    deleteGroup(data: IGroupDeletionParams): Promise<void>;
     updateScenes(scenes: ISceneDataArray): Promise<void>;
+    updateParticipants(participants: IParticipantArray): Promise<void>;
     giveInput<T extends IInput>(_: T): Promise<void>;
 
     getTime(): Promise<number>;

--- a/src/IClient.ts
+++ b/src/IClient.ts
@@ -4,13 +4,13 @@ import { ClientType } from './Client';
 import { InteractiveError } from './errors';
 import {
     IControl,
-    IGroupDeletionParams,
     IGroupDataArray,
+    IGroupDeletionParams,
     IInput,
+    IParticipantArray,
     ISceneControlDeletion,
     ISceneData,
     ISceneDataArray,
-    IParticipantArray
 } from './state/interfaces';
 import { IState } from './state/IState';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import { InteractiveSocket } from './wire/Socket';
 export * from './state/interfaces';
+export * from './state/Scene';
+export * from './state/Group';
 export * from './IClient';
 export * from './GameClient';
 export * from './ParticipantClient';

--- a/src/state/Group.ts
+++ b/src/state/Group.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 
 import { merge } from '../merge';
 import { IMeta } from './interfaces/controls';
-import { IGroup } from './interfaces/IGroup';
+import { IGroup, IGroupData } from './interfaces/IGroup';
 
 /**
  * A Group is a collection of participants.
@@ -13,7 +13,7 @@ export class Group extends EventEmitter implements IGroup {
     public etag: string;
     public meta: IMeta = {};
 
-    constructor(group: IGroup) {
+    constructor(group: IGroupData) {
         super();
         merge(this, group);
     }
@@ -23,7 +23,7 @@ export class Group extends EventEmitter implements IGroup {
     /**
      * Updates this group with new data from the server.
      */
-    public update(data: IGroup) {
+    public update(data: IGroupData) {
         merge(this, data);
         this.emit('updated', this);
     }

--- a/src/state/IState.ts
+++ b/src/state/IState.ts
@@ -5,7 +5,7 @@ import { Method, Reply } from '../wire/packets';
 import { Group } from './Group';
 import { IScene, ISceneData, ISceneDataArray } from './interfaces';
 import { IControl } from './interfaces/controls/IControl';
-import { IGroup } from './interfaces/IGroup';
+import { IGroup, IGroupDataArray } from './interfaces/IGroup';
 import { IParticipant } from './interfaces/IParticipant';
 
 export interface IState extends EventEmitter {
@@ -20,6 +20,7 @@ export interface IState extends EventEmitter {
     getScene(id: string): IScene;
     onSceneCreate(data: ISceneData): IScene;
     synchronizeScenes(data: ISceneDataArray): IScene[];
+    synchronizeGroups(data: IGroupDataArray): IGroup[];
 
     getControl(id: string): IControl;
 

--- a/src/state/State.ts
+++ b/src/state/State.ts
@@ -11,7 +11,7 @@ import { Method, Reply } from '../wire/packets';
 import { Group } from './Group';
 import { IParticipant, IScene, ISceneDataArray } from './interfaces';
 import { IControl } from './interfaces/controls/IControl';
-import { IGroup } from './interfaces/IGroup';
+import { IGroup, IGroupData, IGroupDataArray } from './interfaces/IGroup';
 import { ISceneData } from './interfaces/IScene';
 import { Scene } from './Scene';
 import { StateFactory } from './StateFactory';
@@ -119,6 +119,10 @@ export class State extends EventEmitter implements IState {
      */
     public synchronizeScenes(data: ISceneDataArray): IScene[] {
         return data.scenes.map(scene => this.onSceneCreate(scene));
+    }
+
+    public synchronizeGroups(data: IGroupDataArray): IGroup[] {
+        return data.groups.map(group => this.onGroupCreate(group));
     }
 
     private addParticipantHandlers() {
@@ -267,7 +271,7 @@ export class State extends EventEmitter implements IState {
     /**
      * Updates an existing scene in the game session.
      */
-    public onGroupUpdate(group: IGroup) {
+    public onGroupUpdate(group: IGroupData) {
         const targetGroup = this.getGroup(group.groupID);
         if (targetGroup) {
             targetGroup.update(group);
@@ -289,7 +293,7 @@ export class State extends EventEmitter implements IState {
     /**
      * Inserts a new group into the game session.
      */
-    public onGroupCreate(data: IGroup): Group {
+    public onGroupCreate(data: IGroupData): Group {
         let group = this.groups.get(data.groupID);
         if (group) {
             if (group.etag === data.etag) {

--- a/src/state/interfaces/IGroup.ts
+++ b/src/state/interfaces/IGroup.ts
@@ -3,7 +3,7 @@ import { ETag } from './';
 import { IMeta } from './controls/IMeta';
 
 export interface IGroupDataArray {
-    groups: IGroup[];
+    groups: IGroupData[];
 }
 
 export interface IGroupDeletionParams {
@@ -11,7 +11,7 @@ export interface IGroupDeletionParams {
     reassignGroupID: string;
 }
 
-export interface IGroup extends EventEmitter {
+export interface IGroupData {
     /**
      * The ID of the group.
      */
@@ -31,7 +31,9 @@ export interface IGroup extends EventEmitter {
      * The group's ETag.
      */
     etag?: ETag;
+}
 
+export interface IGroup extends EventEmitter, IGroupData {
     /**
      * Fired when the group is updated with new data from the server.
      */

--- a/src/state/interfaces/index.ts
+++ b/src/state/interfaces/index.ts
@@ -1,3 +1,4 @@
+export * from './IGroup';
 export * from './IScene';
 export * from './IParticipant';
 export * from './controls';


### PR DESCRIPTION
Adding the following GameClient functions:
 - createGroups
 - updateGroups
 - createScenes
 - updateParticipants

Add the following Client functions:
 - synchronizeGroups
 - getGroups

Minor refactor of IGroup* interfaces to align with I<Name>, I<Name>Data,
I<Name>DataArray pattern used elsewhere.

Update the IClient.deleteGroup method signature to use the correct
IGroupDeletionParams interface. Interestingly this method does not seem
to yet be supported by the interactive service...

Update TODO.md with added functions.

Added the `groups` example for creating groups and scenes and switching between them.